### PR TITLE
Update "See this talk at Open Source Bridge" text to show the current event's year.

### DIFF
--- a/app/views/open_conference_ware/proposals/_see_this_talk.html.erb
+++ b/app/views/open_conference_ware/proposals/_see_this_talk.html.erb
@@ -1,5 +1,5 @@
 <% if @proposal.event.current? && Date.today < @proposal.event.dates.first %>
   <div class='see-this-talk'>
-    <h4>See this talk at Open Source Bridge 2015! <%= link_to "Register today!", "https://osbridge.eventbrite.com/" %></h4>
+    <h4>See this talk at Open Source Bridge <%= @proposal.event.dates.first.year %>! <%= link_to "Register today!", "https://osbridge.eventbrite.com/" %></h4>
   </div>
 <% end %>


### PR DESCRIPTION
Fix for osbridge/planning#297

Can someone test this to make sure it works? My setup isn't current right now so I didn't test it yet.
